### PR TITLE
Bumping lib version for Deno 1.2

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { Tar, Untar } from "https://deno.land/std@0.60.0/archive/tar.ts";
-export { ensureFile } from "https://deno.land/std@0.60.0/fs/ensure_file.ts";
-export { ensureDir } from "https://deno.land/std@0.60.0/fs/ensure_dir.ts";
-export { resolve, basename } from "https://deno.land/std@0.60.0/path/mod.ts";
+export { Tar, Untar } from "https://deno.land/std@0.61.0/archive/tar.ts";
+export { ensureFile } from "https://deno.land/std@0.61.0/fs/ensure_file.ts";
+export { ensureDir } from "https://deno.land/std@0.61.0/fs/ensure_dir.ts";
+export { resolve, basename } from "https://deno.land/std@0.61.0/path/mod.ts";


### PR DESCRIPTION
Deno 1.2 has breaking changes hence it needs 0.61 version of libs