### PR TITLE
fix: error because of importsNotUsedAsValues with deno 1.4 --unstable

### DIFF
--- a/tar/mod.ts
+++ b/tar/mod.ts
@@ -1,5 +1,5 @@
 import { Tar, Untar, ensureDir, path } from "../deps.ts";
-import { compressInterface } from "../interface.ts";
+import type { compressInterface } from "../interface.ts";
 
 export async function uncompress(src: string, dest: string): Promise<void> {
   const reader = await Deno.open(src, { read: true });

--- a/tgz/mod.ts
+++ b/tgz/mod.ts
@@ -1,6 +1,6 @@
 import * as tar from "../tar/mod.ts";
 import { gzipFile, gunzipFile } from "../gzip/gzip_file.ts";
-import { compressInterface } from "../interface.ts";
+import type { compressInterface } from "../interface.ts";
 import { path } from "../deps.ts";
 
 export async function uncompress(src: string, dest: string): Promise<void> {

--- a/zlib/zlib/deflate.ts
+++ b/zlib/zlib/deflate.ts
@@ -1,5 +1,5 @@
 import { message as msg, CODE } from "./messages.ts";
-import ZStream from "./zstream.ts";
+import type ZStream from "./zstream.ts";
 import * as trees from "./trees.ts";
 import adler32 from "./adler32.ts";
 import { crc32 } from "./crc32.ts";

--- a/zlib/zlib/inflate.ts
+++ b/zlib/zlib/inflate.ts
@@ -2,7 +2,7 @@ import adler32 from "./adler32.ts";
 import { crc32 } from "./crc32.ts";
 import inflate_fast from "./inffast.ts";
 import inflate_table from "./inftrees.ts";
-import ZStream from "./zstream.ts";
+import type ZStream from "./zstream.ts";
 
 const CODES = 0;
 const LENS = 1;


### PR DESCRIPTION
see https://deno.land/posts/v1.4#stricter-type-checks-in-code--unstablecode