### PR TITLE
Update std/archive version, try to fix #16

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { Tar, Untar } from "https://deno.land/std@0.129.0/archive/tar.ts";
+export { Tar, Untar } from "https://deno.land/std@0.213.0/archive/mod.ts";
 export { ensureFile } from "https://deno.land/std@0.129.0/fs/ensure_file.ts";
 export { ensureDir } from "https://deno.land/std@0.129.0/fs/ensure_dir.ts";
 export { EventEmitter } from "https://deno.land/std@0.129.0/node/events.ts";


### PR DESCRIPTION
This should remove warning.

I tried to update other dependencies, but those libraries change a lot. And codes in gzip are using many deprecated api too. Anyway, only update achieve should remove the warning.

Feel free to edit/close this pr.